### PR TITLE
Unknown fallthrough - wrapper for unsupported records + SignatureRecord fixes

### DIFF
--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefEncoderException.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefEncoderException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011 Adrian Stabiszewski, as@nfctools.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nfctools.ndef;
+
+/**
+ * Exception for determining the source of the exception. 
+ * 
+ * @author Thomas Rorvik Skjolberg (skjolber@gmail.com)
+ * 
+ */
+
+public class NdefEncoderException extends IllegalArgumentException {
+
+	private static final long serialVersionUID = 1L;
+	
+	private Record location;
+	
+	public NdefEncoderException(String message, Record location) {
+		super(message);
+		
+		this.location = location;
+	}
+
+	public Record getLocation() {
+		return location;
+	}
+
+	
+}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefEncoderException.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefEncoderException.java
@@ -23,7 +23,7 @@ package org.nfctools.ndef;
  * 
  */
 
-public class NdefEncoderException extends IllegalArgumentException {
+public class NdefEncoderException extends NdefException {
 
 	private static final long serialVersionUID = 1L;
 	

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefException.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefException.java
@@ -15,13 +15,26 @@
  */
 package org.nfctools.ndef;
 
-import java.io.IOException;
 
-public class NdefException extends IOException {
+public class NdefException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
 	public NdefException(String message) {
 		super(message);
 	}
+
+	public NdefException() {
+		super();
+	}
+
+	public NdefException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public NdefException(Throwable throwable) {
+		super(throwable);
+	}
+	
+	
 }

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefMessageDecoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefMessageDecoder.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class NdefMessageDecoder {
 
 	private NdefRecordDecoder ndefRecordDecoder;
-
+	
 	public NdefMessageDecoder(NdefRecordDecoder ndefRecordDecoder) {
 		this.ndefRecordDecoder = ndefRecordDecoder;
 	}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefMessageDecoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefMessageDecoder.java
@@ -144,7 +144,7 @@ public class NdefMessageDecoder {
 		try {
 			while (bais.available() > 0) {
 				int header = bais.read();
-				short tnf = (short)(header & NdefConstants.TNF_MASK);
+				byte tnf = (byte)(header & NdefConstants.TNF_MASK);
 
 				int typeLength = bais.read();
 				int payloadLength = getPayloadLength((header & NdefConstants.SR) != 0, bais);

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefRecord.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefRecord.java
@@ -23,7 +23,7 @@ package org.nfctools.ndef;
 
 public class NdefRecord {
 
-	private short tnf;
+	private byte tnf;
 	/** An identifier that indicates the type of the payload. This specification supports URIs
 	  *	[RFC 3986], MIME media type constructs [RFC 2616], as well as an NFC-specific
 	  *	record type as type identifiers. 
@@ -41,14 +41,14 @@ public class NdefRecord {
 	 */
 	private boolean chunked = false;
 
-	public NdefRecord(short tnf, boolean chunked, byte[] type, byte[] id, byte[] payload) {
+	public NdefRecord(byte tnf, boolean chunked, byte[] type, byte[] id, byte[] payload) {
 		this.tnf = tnf;
 		this.chunked = chunked;
 		this.type = type;
 		this.id = id;
 		this.payload = payload;
 	}
-	public NdefRecord(short tnf, byte[] type, byte[] id, byte[] payload) {
+	public NdefRecord(byte tnf, byte[] type, byte[] id, byte[] payload) {
 		this(tnf, false, type, id, payload);
 	}
 
@@ -56,7 +56,7 @@ public class NdefRecord {
 		return chunked;
 	}
 	
-	public short getTnf() {
+	public byte getTnf() {
 		return tnf;
 	}
 

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefRecordDecoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefRecordDecoder.java
@@ -23,6 +23,7 @@ import org.nfctools.ndef.empty.EmptyRecordDecoder;
 import org.nfctools.ndef.ext.ExternalTypeDecoder;
 import org.nfctools.ndef.mime.MimeRecordDecoder;
 import org.nfctools.ndef.unknown.UnknownRecordDecoder;
+import org.nfctools.ndef.unknown.unsupported.UnsupportedRecord;
 import org.nfctools.ndef.wkt.WellKnownRecordConfig;
 import org.nfctools.ndef.wkt.WellKnownRecordDecoder;
 import org.nfctools.ndef.wkt.decoder.RecordDecoder;
@@ -52,7 +53,13 @@ public class NdefRecordDecoder {
 			if (decoder.canDecode(ndefRecord))
 				return decoder.decodeRecord(ndefRecord, messageDecoder);
 		}
-		throw new IllegalArgumentException("Unsupported NDEF Type Name Format [" + ndefRecord.getTnf() + "]");
+		
+		// NFC Data Exchange Format (NDEF) 1.0:
+		// An NDEF parser that receives an NDEF record with an unknown or unsupported TNF field value SHOULD treat it as 0x05 (Unknown).
+		// It is RECOMMENDED that an NDEF parser receiving an NDEF record of this type, 
+		// without further context to its use, provides a mechanism for storing but not processing the payload.
+		
+		return new UnsupportedRecord(ndefRecord);
 	}
 
 	public void registerRecordConfig(WellKnownRecordConfig recordconfig) {

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/NdefRecordEncoder.java
@@ -23,6 +23,7 @@ import org.nfctools.ndef.empty.EmptyRecordEncoder;
 import org.nfctools.ndef.ext.ExternalTypeEncoder;
 import org.nfctools.ndef.mime.MimeRecordEncoder;
 import org.nfctools.ndef.unknown.UnknownRecordEncoder;
+import org.nfctools.ndef.unknown.unsupported.UnsupportedRecordEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordConfig;
 import org.nfctools.ndef.wkt.WellKnownRecordEncoder;
 import org.nfctools.ndef.wkt.encoder.RecordEncoder;
@@ -39,6 +40,7 @@ public class NdefRecordEncoder {
 		knownRecordEncoders.add(new ExternalTypeEncoder());
 		knownRecordEncoders.add(new EmptyRecordEncoder());
 		knownRecordEncoders.add(new UnknownRecordEncoder());
+		knownRecordEncoders.add(new UnsupportedRecordEncoder());
 	}
 
 	public NdefRecord encode(Record record, NdefMessageEncoder messageEncoder) {

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/auri/AbsoluteUriRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/auri/AbsoluteUriRecordEncoder.java
@@ -17,6 +17,7 @@
 package org.nfctools.ndef.auri;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.NdefRecord;
 import org.nfctools.ndef.Record;
@@ -38,6 +39,11 @@ public class AbsoluteUriRecordEncoder implements RecordEncoder {
 	@Override
 	public NdefRecord encodeRecord(Record record, NdefMessageEncoder messageEncoder) {
 		AbsoluteUriRecord absoluteUriRecord = (AbsoluteUriRecord)record;
+		
+		if(!absoluteUriRecord.hasUri()) {
+			throw new NdefEncoderException("Expected URI", record);
+		}
+		
 		return new NdefRecord(NdefConstants.TNF_ABSOLUTE_URI, AbsoluteUriRecord.TYPE, absoluteUriRecord.getId(),
 				absoluteUriRecord.getUri().getBytes(NdefConstants.DEFAULT_CHARSET));
 	}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/ext/ExternalTypeEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/ext/ExternalTypeEncoder.java
@@ -16,6 +16,7 @@
 package org.nfctools.ndef.ext;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.NdefRecord;
 import org.nfctools.ndef.Record;
@@ -31,6 +32,14 @@ public class ExternalTypeEncoder implements RecordEncoder {
 	@Override
 	public NdefRecord encodeRecord(Record record, NdefMessageEncoder messageEncoder) {
 		ExternalTypeRecord externalType = (ExternalTypeRecord)record;
+		
+		if(!externalType.hasNamespace()) {
+			throw new NdefEncoderException("Expected namespace", record);
+		}
+		if(!externalType.hasContent()) {
+			throw new NdefEncoderException("Expected content", record);
+		}
+		
 		byte[] type = externalType.getNamespace().getBytes(NdefConstants.DEFAULT_CHARSET);
 		byte[] paylod = externalType.getContent().getBytes(NdefConstants.DEFAULT_CHARSET);
 		return new NdefRecord(NdefConstants.TNF_EXTERNAL_TYPE, type, record.getId(), paylod);

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/mime/MimeRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/mime/MimeRecordEncoder.java
@@ -16,6 +16,7 @@
 package org.nfctools.ndef.mime;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.NdefRecord;
 import org.nfctools.ndef.Record;
@@ -32,6 +33,10 @@ public class MimeRecordEncoder implements RecordEncoder {
 	public NdefRecord encodeRecord(Record record, NdefMessageEncoder messageEncoder) {
 		MimeRecord mimeRecord = (MimeRecord)record;
 
+		if(!mimeRecord.hasContentType()) {
+			throw new NdefEncoderException("Expected content type", mimeRecord);
+		}
+		
 		return new NdefRecord(NdefConstants.TNF_MIME_MEDIA, mimeRecord.getContentType().getBytes(
 						NdefConstants.DEFAULT_CHARSET), record.getId(), mimeRecord.getContentAsBytes());
 	}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/unknown/unsupported/UnsupportedRecord.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/unknown/unsupported/UnsupportedRecord.java
@@ -1,0 +1,93 @@
+package org.nfctools.ndef.unknown.unsupported;
+
+import java.util.Arrays;
+
+import org.nfctools.ndef.NdefRecord;
+import org.nfctools.ndef.Record;
+
+/**
+ * 
+ * A record which is not supported by this system and thus is handled on a byte-buffer level.
+ * 
+ * @author Thomas Rorvik Skjolberg (skjolber@gmail.com)
+ * 
+ */
+
+public class UnsupportedRecord extends Record {
+
+	private byte tnf;
+	
+	/** An identifier that indicates the type of the payload. This specification supports URIs
+	  *	[RFC 3986], MIME media type constructs [RFC 2616], as well as an NFC-specific
+	  *	record type as type identifiers. 
+	  */
+	private byte[] type;
+	
+	/** The application data carried within an NDEF record. */
+	private byte[] payload;
+
+	public UnsupportedRecord(byte tnf, byte[] type, byte[] id, byte[] payload) {
+		this.tnf = tnf;
+		this.type = type;
+		this.id = id;
+		this.payload = payload;
+	}
+	
+	public UnsupportedRecord(NdefRecord record) {
+		this(record.getTnf(), record.getType(), record.getId(), record.getPayload());
+	}
+
+	public byte getTnf() {
+		return tnf;
+	}
+
+	public void setTnf(byte tnf) {
+		this.tnf = tnf;
+	}
+
+	public byte[] getType() {
+		return type;
+	}
+
+	public void setType(byte[] type) {
+		this.type = type;
+	}
+
+	public byte[] getPayload() {
+		return payload;
+	}
+
+	public void setPayload(byte[] payload) {
+		this.payload = payload;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Arrays.hashCode(payload);
+		result = prime * result + tnf;
+		result = prime * result + Arrays.hashCode(type);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		UnsupportedRecord other = (UnsupportedRecord) obj;
+		if (!Arrays.equals(payload, other.payload))
+			return false;
+		if (tnf != other.tnf)
+			return false;
+		if (!Arrays.equals(type, other.type))
+			return false;
+		return true;
+	}
+
+	
+}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/unknown/unsupported/UnsupportedRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/unknown/unsupported/UnsupportedRecordEncoder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2011 Adrian Stabiszewski, as@nfctools.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nfctools.ndef.unknown.unsupported;
+
+import org.nfctools.ndef.NdefMessageEncoder;
+import org.nfctools.ndef.NdefRecord;
+import org.nfctools.ndef.Record;
+import org.nfctools.ndef.wkt.encoder.RecordEncoder;
+
+/**
+ * 
+ * @author Thomas Rorvik Skjolberg (skjolber@gmail.com)
+ * 
+ */
+
+public class UnsupportedRecordEncoder implements RecordEncoder {
+
+	@Override
+	public boolean canEncode(Record record) {
+		return record instanceof UnsupportedRecord;
+	}
+
+	@Override
+	public NdefRecord encodeRecord(Record record, NdefMessageEncoder messageEncoder) {
+		UnsupportedRecord unsupportedRecord = (UnsupportedRecord)record;
+		
+		return new NdefRecord(unsupportedRecord.getTnf(), unsupportedRecord.getType(), unsupportedRecord.getId(), unsupportedRecord.getPayload());
+	}
+
+}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/WellKnownRecordDecoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/WellKnownRecordDecoder.java
@@ -16,7 +16,10 @@ public class WellKnownRecordDecoder implements RecordDecoder<WellKnownRecord> {
 
 	@Override
 	public boolean canDecode(NdefRecord ndefRecord) {
-		return NdefConstants.TNF_WELL_KNOWN == ndefRecord.getTnf();
+		if(NdefConstants.TNF_WELL_KNOWN == ndefRecord.getTnf()) {
+			return recordDecoders.containsKey(new RecordType(ndefRecord.getType()));
+		}
+		return false;
 	}
 
 	@Override

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/WellKnownRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/WellKnownRecordEncoder.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.NdefRecord;
 import org.nfctools.ndef.Record;
@@ -21,10 +22,18 @@ public class WellKnownRecordEncoder implements RecordEncoder {
 
 	@Override
 	public NdefRecord encodeRecord(Record record, NdefMessageEncoder messageEncoder) {
+
+		byte[] key = record.getId();
+		if(key != null) {
+			if(key.length > 255) {
+				throw new NdefEncoderException("Expected record id length <= 255 bytes", record);
+			}
+		}
+		
 		WellKnownRecordConfig config = knownRecordTypes.get(record.getClass());
 		byte[] payload = config.getPayloadEncoder().encodePayload((WellKnownRecord)record, messageEncoder);
 		byte[] type = config.getRecordType().getType();
-		return new NdefRecord(NdefConstants.TNF_WELL_KNOWN, type, record.getId(), payload);
+		return new NdefRecord(NdefConstants.TNF_WELL_KNOWN, type, key, payload);
 	}
 
 	public void addRecordConfig(WellKnownRecordConfig config) {

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/decoder/SignatureRecordDecoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/decoder/SignatureRecordDecoder.java
@@ -16,9 +16,7 @@
 package org.nfctools.ndef.wkt.decoder;
 
 import java.io.ByteArrayInputStream;
-import java.io.EOFException;
 import java.io.IOException;
-import java.io.InputStream;
 
 import org.nfctools.ndef.NdefConstants;
 import org.nfctools.ndef.NdefMessageDecoder;
@@ -46,16 +44,20 @@ public class SignatureRecordDecoder implements WellKnownRecordPayloadDecoder {
 			boolean signatureUriPresent = (header & 0x80) != 0;
 			SignatureType type = SignatureType.toSignatureType((header & 0x7F));
 			
+			signatureRecord.setSignatureType(type);
+			
 			if(signatureUriPresent || type != SignatureType.NOT_PRESENT) {
 				
 				int size = RecordUtils.readUnsignedShort(bais);
 
-				byte[] signatureOrUri = RecordUtils.readByteArray(bais, size);
-
-				if(signatureUriPresent) {
-					signatureRecord.setSignatureUri(new String(signatureOrUri, NdefConstants.UTF_8_CHARSET));
-				} else {
-					signatureRecord.setSignature(signatureOrUri);
+				if(size > 0) {
+					byte[] signatureOrUri = RecordUtils.readByteArray(bais, size);
+	
+					if(signatureUriPresent) {
+						signatureRecord.setSignatureUri(new String(signatureOrUri, NdefConstants.UTF_8_CHARSET));
+					} else {
+						signatureRecord.setSignature(signatureOrUri);
+					}
 				}
 				
 				int certificateHeader = bais.read();

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/ActionRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/ActionRecordEncoder.java
@@ -15,6 +15,7 @@
  */
 package org.nfctools.ndef.wkt.encoder;
 
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.records.ActionRecord;
@@ -26,7 +27,7 @@ public class ActionRecordEncoder implements WellKnownRecordPayloadEncoder {
 	public byte[] encodePayload(WellKnownRecord wellKnownRecord, NdefMessageEncoder messageEncoder) {
 		ActionRecord record = (ActionRecord)wellKnownRecord;
 		if (!record.hasAction()) {
-			throw new IllegalArgumentException("Expected action");
+			throw new NdefEncoderException("Expected action", wellKnownRecord);
 		}
 		return new byte[] { record.getAction().getValue() };
 	}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/GcTargetRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/GcTargetRecordEncoder.java
@@ -15,6 +15,7 @@
  */
 package org.nfctools.ndef.wkt.encoder;
 
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.records.GcTargetRecord;
@@ -26,8 +27,8 @@ public class GcTargetRecordEncoder implements WellKnownRecordPayloadEncoder {
 	public byte[] encodePayload(WellKnownRecord wellKnownRecord, NdefMessageEncoder messageEncoder) {
 		GcTargetRecord gcTargetRecord = (GcTargetRecord)wellKnownRecord;
 		if (!gcTargetRecord.hasTargetIdentifier()) {
-			throw new IllegalArgumentException(wellKnownRecord.getClass().getSimpleName()
-					+ " must have target identifier");
+			throw new NdefEncoderException(wellKnownRecord.getClass().getSimpleName()
+					+ " must have target identifier", wellKnownRecord);
 		}
 		return messageEncoder.encodeSingle(gcTargetRecord.getTargetIdentifier());
 	}

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/GenericControlRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/GenericControlRecordEncoder.java
@@ -18,6 +18,7 @@ package org.nfctools.ndef.wkt.encoder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.records.GenericControlRecord;
@@ -29,17 +30,14 @@ public class GenericControlRecordEncoder implements WellKnownRecordPayloadEncode
 	public byte[] encodePayload(WellKnownRecord wellKnownRecord, NdefMessageEncoder messageEncoder) {
 		GenericControlRecord myRecord = (GenericControlRecord)wellKnownRecord;
 
-		byte[] subPayload = createSubPayload(messageEncoder, myRecord);
-		byte[] payload = new byte[subPayload.length + 1];
-		payload[0] = myRecord.getConfigurationByte();
-		System.arraycopy(subPayload, 0, payload, 1, subPayload.length);
-
-		return payload;
-	}
-
-	private byte[] createSubPayload(NdefMessageEncoder messageEncoder, GenericControlRecord myRecord) {
 		try {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			
+			baos.write(myRecord.getConfigurationByte());
+
+			if(!myRecord.hasTarget()) {
+				throw new NdefEncoderException("Expected target", myRecord);
+			}
 			baos.write(messageEncoder.encodeSingle(myRecord.getTarget()));
 
 			if (myRecord.getAction() != null)

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/SignatureRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/SignatureRecordEncoder.java
@@ -32,13 +32,14 @@ public class SignatureRecordEncoder implements WellKnownRecordPayloadEncoder {
 				if(!signatureRecord.hasSignatureType()) {
 					throw new NdefEncoderException("Expected signature type", signatureRecord);
 				}
-				baos.write((1 << 7) | (signatureRecord.getSignatureType().getValue() & 0x7F));
 
 				if(signatureRecord.hasSignature() && signatureRecord.hasSignatureUri()) {
 					throw new NdefEncoderException("Expected signature or signature uri, not both", signatureRecord);
 				} else if(!signatureRecord.hasSignature() && !signatureRecord.hasSignatureUri()) {
 					throw new NdefEncoderException("Expected signature or signature uri", signatureRecord);
 				}
+
+				baos.write(((signatureRecord.hasSignatureUri() ? 1 : 0) << 7) | (signatureRecord.getSignatureType().getValue() & 0x7F));
 
 				byte[] signatureOrUri;
 				if(signatureRecord.hasSignature()) {

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/SignatureRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/SignatureRecordEncoder.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.records.SignatureRecord;
@@ -29,14 +30,14 @@ public class SignatureRecordEncoder implements WellKnownRecordPayloadEncoder {
 				baos.write(signatureRecord.getVersion());
 
 				if(!signatureRecord.hasSignatureType()) {
-					throw new IllegalArgumentException("Expected signature type");
+					throw new NdefEncoderException("Expected signature type", signatureRecord);
 				}
 				baos.write((1 << 7) | (signatureRecord.getSignatureType().getValue() & 0x7F));
 
 				if(signatureRecord.hasSignature() && signatureRecord.hasSignatureUri()) {
-					throw new IllegalArgumentException("Expected signature or signature uri, not both");
+					throw new NdefEncoderException("Expected signature or signature uri, not both", signatureRecord);
 				} else if(!signatureRecord.hasSignature() && !signatureRecord.hasSignatureUri()) {
-					throw new IllegalArgumentException("Expected signature or signature uri");
+					throw new NdefEncoderException("Expected signature or signature uri", signatureRecord);
 				}
 
 				byte[] signatureOrUri;
@@ -44,13 +45,13 @@ public class SignatureRecordEncoder implements WellKnownRecordPayloadEncoder {
 					signatureOrUri = signatureRecord.getSignature();
 
 					if(signatureOrUri.length > 65535) {
-						throw new IllegalArgumentException("Expected signature size " + signatureOrUri.length + " <= 65535");
+						throw new NdefEncoderException("Expected signature size " + signatureOrUri.length + " <= 65535", signatureRecord);
 					}
 				} else {
 					signatureOrUri = signatureRecord.getSignatureUri().getBytes(NdefConstants.UTF_8_CHARSET);
 
 					if(signatureOrUri.length > 65535) {
-						throw new IllegalArgumentException("Expected signature uri byte size " + signatureOrUri.length + " <= 65535");
+						throw new NdefEncoderException("Expected signature uri byte size " + signatureOrUri.length + " <= 65535", signatureRecord);
 					}
 				}
 
@@ -60,12 +61,12 @@ public class SignatureRecordEncoder implements WellKnownRecordPayloadEncoder {
 				baos.write(signatureOrUri);
 
 				if(!signatureRecord.hasCertificateFormat()) {
-					throw new IllegalArgumentException("Expected certificate format");
+					throw new NdefEncoderException("Expected certificate format", signatureRecord);
 				}
 
 				List<byte[]> certificates = signatureRecord.getCertificates();
 				if(certificates.size() > 16) {
-					throw new IllegalArgumentException("Expected number of certificates " + certificates.size() + " <= 15");
+					throw new NdefEncoderException("Expected number of certificates " + certificates.size() + " <= 15", signatureRecord);
 				}
 
 				CertificateFormat certificateFormat = signatureRecord.getCertificateFormat();
@@ -75,7 +76,7 @@ public class SignatureRecordEncoder implements WellKnownRecordPayloadEncoder {
 					byte[] certificate = certificates.get(i);
 
 					if(certificate.length > 65535) {
-						throw new IllegalArgumentException("Expected certificate " + i + " size " + certificate.length + " <= 65535");
+						throw new NdefEncoderException("Expected certificate " + i + " size " + certificate.length + " <= 65535", signatureRecord);
 					}
 
 					baos.write((certificate.length >> 8) & 0xFF);
@@ -88,7 +89,7 @@ public class SignatureRecordEncoder implements WellKnownRecordPayloadEncoder {
 					byte[] certificateUri = signatureRecord.getCertificateUri().getBytes(NdefConstants.UTF_8_CHARSET);
 
 					if(certificateUri.length > 65535) {
-						throw new IllegalArgumentException("Expected certificate uri byte size " + certificateUri.length + " <= 65535");
+						throw new NdefEncoderException("Expected certificate uri byte size " + certificateUri.length + " <= 65535", signatureRecord);
 					}
 
 					baos.write((certificateUri.length >> 8) & 0xFF);

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/TextRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/TextRecordEncoder.java
@@ -19,6 +19,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Locale;
 
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.records.TextRecord;
@@ -31,14 +32,27 @@ public class TextRecordEncoder implements WellKnownRecordPayloadEncoder {
 
 		TextRecord textRecord = (TextRecord)wellKnownRecord;
 
+		if(!textRecord.hasLocale()) {
+			throw new NdefEncoderException("Expected locale", wellKnownRecord);
+		}
+
+		if(!textRecord.hasEncoding()) {
+			throw new NdefEncoderException("Expected encoding", wellKnownRecord);
+		}
+
+		if(!textRecord.hasText()) {
+			throw new NdefEncoderException("Expected text", wellKnownRecord);
+		}
+
 		Locale locale = textRecord.getLocale();
 
 		byte[] languageData = (locale.getLanguage() + (locale.getCountry() == null || locale.getCountry().length() == 0 ? ""
 				: ("-" + locale.getCountry()))).getBytes();
 
-		if (languageData.length > TextRecord.LANGUAGE_CODE_MASK)
-			throw new IllegalArgumentException("language code length longer than 2^5. this is not supported.");
-
+		if (languageData.length > TextRecord.LANGUAGE_CODE_MASK) {
+			throw new NdefEncoderException("language code length longer than 2^5. this is not supported.", wellKnownRecord);
+		}
+		
 		Charset encoding = textRecord.getEncoding();
 
 		byte[] textData = getTextAsBytes(textRecord, encoding);

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/UriRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/encoder/UriRecordEncoder.java
@@ -17,6 +17,7 @@ package org.nfctools.ndef.wkt.encoder;
 
 import java.io.UnsupportedEncodingException;
 
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.records.UriRecord;
@@ -27,6 +28,11 @@ public class UriRecordEncoder implements WellKnownRecordPayloadEncoder {
 	@Override
 	public byte[] encodePayload(WellKnownRecord wellKnownRecord, NdefMessageEncoder messageEncoder) {
 		UriRecord uriRecord = (UriRecord)wellKnownRecord;
+		
+		if(!uriRecord.hasUri()) {
+			throw new NdefEncoderException("Expected URI", wellKnownRecord);
+		}
+
 		String uri = uriRecord.getUri();
 		byte[] uriAsBytes = getUriAsBytes(uri);
 

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/handover/encoder/AlternativeCarrierRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/handover/encoder/AlternativeCarrierRecordEncoder.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.List;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
 import org.nfctools.ndef.wkt.handover.records.AlternativeCarrierRecord;
@@ -44,19 +45,19 @@ public class AlternativeCarrierRecordEncoder implements WellKnownRecordPayloadEn
 		// cps
 		CarrierPowerState carrierPowerState = alternativeCarrierRecord.getCarrierPowerState();
 		if (carrierPowerState == null) {
-			throw new IllegalArgumentException("Expected carrier power state");
+			throw new NdefEncoderException("Expected carrier power state", alternativeCarrierRecord);
 		}
 		bout.write(carrierPowerState.getValue() & 0x7); // 3 lsb
 
 		// carrier data reference: 1
 		String carrierDataReference = alternativeCarrierRecord.getCarrierDataReference();
 		if (carrierDataReference == null) {
-			throw new IllegalArgumentException("Expected carrier data reference");
+			throw new NdefEncoderException("Expected carrier data reference", alternativeCarrierRecord);
 		}
 		byte[] carrierDataReferenceChar = carrierDataReference.getBytes(NdefConstants.DEFAULT_CHARSET);
 		if (carrierDataReferenceChar.length > 255) {
-			throw new IllegalArgumentException("Expected carrier data reference '" + carrierDataReference
-					+ "' <= 255 bytes");
+			throw new NdefEncoderException("Expected carrier data reference '" + carrierDataReference
+					+ "' <= 255 bytes", alternativeCarrierRecord);
 		}
 		// carrier data reference length (1)
 		bout.write(carrierDataReferenceChar.length);
@@ -74,8 +75,8 @@ public class AlternativeCarrierRecordEncoder implements WellKnownRecordPayloadEn
 			// carrier data reference length (1)
 
 			if (auxiliaryDataReferenceChar.length > 255) {
-				throw new IllegalArgumentException("Expected auxiliary data reference '" + auxiliaryDataReference
-						+ "' <= 255 bytes");
+				throw new NdefEncoderException("Expected auxiliary data reference '" + auxiliaryDataReference
+						+ "' <= 255 bytes", alternativeCarrierRecord);
 			}
 
 			bout.write(auxiliaryDataReferenceChar.length);

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/handover/encoder/HandoverCarrierRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/handover/encoder/HandoverCarrierRecordEncoder.java
@@ -19,6 +19,7 @@ package org.nfctools.ndef.wkt.handover.encoder;
 import java.io.ByteArrayOutputStream;
 
 import org.nfctools.ndef.NdefConstants;
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.ext.ExternalTypeRecord;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
@@ -43,7 +44,7 @@ public class HandoverCarrierRecordEncoder implements WellKnownRecordPayloadEncod
 
 		CarrierTypeFormat carrierTypeFormat = handoverCarrierRecord.getCarrierTypeFormat();
 		if (carrierTypeFormat == null) {
-			throw new IllegalArgumentException("Expected carrier type format");
+			throw new NdefEncoderException("Expected carrier type format", handoverCarrierRecord);
 		}
 		bout.write(carrierTypeFormat.getValue() & 0x7);
 
@@ -62,7 +63,7 @@ public class HandoverCarrierRecordEncoder implements WellKnownRecordPayloadEncod
 					break;
 				}
 				else {
-					throw new IllegalArgumentException();
+					throw new NdefEncoderException("Expected well-known record to be of supertype " + WellKnownRecord.class.getName(), handoverCarrierRecord);
 				}
 			}
 			case Media: {
@@ -91,7 +92,7 @@ public class HandoverCarrierRecordEncoder implements WellKnownRecordPayloadEncod
 					break;
 				}
 				else {
-					throw new IllegalArgumentException();
+					throw new NdefEncoderException("Expected external type record to be of supertype " + ExternalTypeRecord.class.getName(), handoverCarrierRecord);
 				}
 			}
 			default: {
@@ -100,7 +101,7 @@ public class HandoverCarrierRecordEncoder implements WellKnownRecordPayloadEncod
 		}
 
 		if (encoded.length > 255) {
-			throw new IllegalArgumentException("Carrier type 255 byte limit exceeded.");
+			throw new NdefEncoderException("Carrier type 255 byte limit exceeded.", handoverCarrierRecord);
 		}
 		bout.write(encoded.length);
 		bout.write(encoded, 0, encoded.length);

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/handover/encoder/HandoverRequestRecordEncoder.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/handover/encoder/HandoverRequestRecordEncoder.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.nfctools.ndef.NdefEncoderException;
 import org.nfctools.ndef.NdefMessageEncoder;
 import org.nfctools.ndef.Record;
 import org.nfctools.ndef.wkt.WellKnownRecordPayloadEncoder;
@@ -45,13 +46,13 @@ public class HandoverRequestRecordEncoder implements WellKnownRecordPayloadEncod
 		payload.write((handoverRequestRecord.getMajorVersion() << 4) | handoverRequestRecord.getMinorVersion());
 
 		if (!handoverRequestRecord.hasCollisionResolution()) {
-			throw new IllegalArgumentException("Expected collision resolution");
+			throw new NdefEncoderException("Expected collision resolution", handoverRequestRecord);
 		}
 
 		// implementation note: write alternative carriers and and collision resolution together
 		if (!handoverRequestRecord.hasAlternativeCarriers()) {
 			// At least a single alternative carrier MUST be specified by the Handover Requester.
-			throw new IllegalArgumentException("Expected at least one alternative carrier");
+			throw new NdefEncoderException("Expected at least one alternative carrier", handoverRequestRecord);
 		}
 		List<Record> records = new ArrayList<Record>();
 

--- a/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/records/SignatureRecord.java
+++ b/nfctools-ndef/src/main/java/org/nfctools/ndef/wkt/records/SignatureRecord.java
@@ -1,6 +1,7 @@
 package org.nfctools.ndef.wkt.records;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -198,5 +199,97 @@ public class SignatureRecord extends WellKnownRecord {
 	public void add(byte[] certificate) {
 		this.certificates.add(certificate);
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime
+				* result
+				+ ((certificateFormat == null) ? 0 : certificateFormat
+						.hashCode());
+		result = prime * result
+				+ ((certificateUri == null) ? 0 : certificateUri.hashCode());
+		result = prime * result
+				+ ((certificates == null) ? 0 : certificatesHash());
+		result = prime * result + Arrays.hashCode(signature);
+		result = prime * result
+				+ ((signatureType == null) ? 0 : signatureType.hashCode());
+		result = prime * result
+				+ ((signatureUri == null) ? 0 : signatureUri.hashCode());
+		result = prime * result + version;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SignatureRecord other = (SignatureRecord) obj;
+		if (certificateFormat != other.certificateFormat)
+			return false;
+		if (certificateUri == null) {
+			if (other.certificateUri != null)
+				return false;
+		} else if (!certificateUri.equals(other.certificateUri))
+			return false;
+		if (!Arrays.equals(signature, other.signature))
+			return false;
+		if (signatureType != other.signatureType)
+			return false;
+		if (signatureUri == null) {
+			if (other.signatureUri != null)
+				return false;
+		} else if (!signatureUri.equals(other.signatureUri))
+			return false;
+		if (version != other.version)
+			return false;
+		
+		return certificatesEquals(other);
+	}
+	
+	private int certificatesHash() {
+		int hash;
+		
+		if(certificates != null) {
+			hash = certificates.size();
+			
+			for(byte[] certificate : certificates) {
+				hash += Arrays.hashCode(certificate);
+			}
+		} else {
+			hash = 0;
+		}
+		return hash;
+	}
+
+	private boolean certificatesEquals(SignatureRecord other) {
+		if (certificates == null) {
+			if (other.certificates != null)
+				return false;
+		} else {
+			if (other.certificates == null) {
+				return false;
+			}
+			if(other.certificates.size() != certificates.size()) {
+				return false;
+			}
+			
+			for(int i = 0; i < certificates.size(); i++) {
+				byte[] otherCertificate = other.certificates.get(i);
+				byte[] thisCertificate = certificates.get(i);
+				
+				if(!Arrays.equals(otherCertificate, thisCertificate)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+	
 	
 }

--- a/nfctools-ndef/src/test/java/org/nfctools/ndef/NdefTestSuite.java
+++ b/nfctools-ndef/src/test/java/org/nfctools/ndef/NdefTestSuite.java
@@ -1,0 +1,24 @@
+package org.nfctools.ndef;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.nfctools.ndef.decoder.GenericControlRecordDecoderTest;
+import org.nfctools.ndef.decoder.HandoverDecoderTest;
+import org.nfctools.ndef.decoder.UriRecordDecoderTest;
+import org.nfctools.ndef.encoder.GenericControlRecordEncoderTest;
+import org.nfctools.ndef.encoder.SmartPosterRecordEncoderTest;
+import org.nfctools.ndef.encoder.TextRecordEncoderTest;
+import org.nfctools.ndef.encoder.UriRecordEncoderTest;
+import org.nfctools.ndef.records.TextRecordTest;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	NdefEncodeDecodeRoundtripTest.class, NdefMessageDecoderTest.class, NdefMessageEncoderTest.class, NdefRecordDecoderTest.class, // base package
+	GenericControlRecordDecoderTest.class, HandoverDecoderTest.class, UriRecordDecoderTest.class, // decoder package
+	GenericControlRecordEncoderTest.class, SmartPosterRecordEncoderTest.class, TextRecordEncoderTest.class, UriRecordEncoderTest.class, // encoder package
+	TextRecordTest.class // records package
+})
+
+public class NdefTestSuite {
+	// empty
+}

--- a/nfctools-ndef/src/test/java/org/nfctools/ndef/encoder/TextRecordEncoderTest.java
+++ b/nfctools-ndef/src/test/java/org/nfctools/ndef/encoder/TextRecordEncoderTest.java
@@ -28,35 +28,43 @@ import org.nfctools.ndef.wkt.encoder.TextRecordEncoder;
 import org.nfctools.ndef.wkt.records.TextRecord;
 import org.nfctools.utils.NfcUtils;
 
+/***
+ * 
+ * Implementation note: Java source files do not really specify encoding, thus special characters might get corrupted.
+ */
+
 public class TextRecordEncoderTest {
 
 	private TextRecordEncoder encoder = new TextRecordEncoder();
 	private NdefMessageEncoder messageEncoder = NdefContext.getNdefMessageEncoder();
 
+	private static String string = new String(new char[]{84, 101, 115, 116, 246, 228, 252, 223, 214, 196, 220, 63});
+	
 	@Test
 	public void testCreateTextRecordUtf8German() throws Exception {
-		TextRecord textRecord = new TextRecord("TestöäüßÖÄÜ?", Charset.forName("utf8"), Locale.GERMAN);
+		
+		TextRecord textRecord = new TextRecord(string, Charset.forName("utf8"), Locale.GERMAN);
 		byte[] bytes = encoder.encodePayload(textRecord, messageEncoder);
 		assertEquals("02646554657374C3B6C3A4C3BCC39FC396C384C39C3F", NfcUtils.convertBinToASCII(bytes));
 	}
 
 	@Test
 	public void testCreateTextRecordUtf16German() throws Exception {
-		TextRecord textRecord = new TextRecord("TestöäüßÖÄÜ?", Charset.forName("utf-16be"), Locale.GERMAN);
+		TextRecord textRecord = new TextRecord(string, Charset.forName("utf-16be"), Locale.GERMAN);
 		byte[] bytes = encoder.encodePayload(textRecord, messageEncoder);
 		assertEquals("826465005400650073007400F600E400FC00DF00D600C400DC003F", NfcUtils.convertBinToASCII(bytes));
 	}
 
 	@Test
 	public void testCreateTextRecordUtf8English() throws Exception {
-		TextRecord textRecord = new TextRecord("TestöäüßÖÄÜ?", Charset.forName("utf8"), Locale.ENGLISH);
+		TextRecord textRecord = new TextRecord(string, Charset.forName("utf8"), Locale.ENGLISH);
 		byte[] bytes = encoder.encodePayload(textRecord, messageEncoder);
 		assertEquals("02656E54657374C3B6C3A4C3BCC39FC396C384C39C3F", NfcUtils.convertBinToASCII(bytes));
 	}
 
 	@Test
 	public void testCreateTextRecordUtf16English() throws Exception {
-		TextRecord textRecord = new TextRecord("TestöäüßÖÄÜ?", Charset.forName("utf-16be"), Locale.ENGLISH);
+		TextRecord textRecord = new TextRecord(string, Charset.forName("utf-16be"), Locale.ENGLISH);
 		byte[] bytes = encoder.encodePayload(textRecord, messageEncoder);
 		assertEquals("82656E005400650073007400F600E400FC00DF00D600C400DC003F", NfcUtils.convertBinToASCII(bytes));
 	}


### PR DESCRIPTION
- Added exception for better locating the source of the problem when attempting encoding of Records with child Records. 
- Added UnsupportedRecord; a fall-through generic type which survives decode/encode operations for compatibility with 3rd party/future systems for top level Records.
- Fixed Signature Record + test cases
- Fixed text encoding test 
- Added test suit
