### PR TITLE
Simple AggregatedFrame compatibility

### DIFF
--- a/nfctools-p2p/src/main/java/org/nfctools/llcp/pdu/AggregatedFrame.java
+++ b/nfctools-p2p/src/main/java/org/nfctools/llcp/pdu/AggregatedFrame.java
@@ -1,0 +1,33 @@
+package org.nfctools.llcp.pdu;
+
+import org.nfctools.llcp.LlcpConnectionManager;
+
+public class AggregatedFrame extends AbstractProtocolDataUnit {
+	
+	protected AbstractProtocolDataUnit[] innerFrames;
+	
+	public AbstractProtocolDataUnit[] getInnerFrames() {
+		return innerFrames;
+	}
+
+	public void setInnerFrames(AbstractProtocolDataUnit[] innerFrames) {
+		this.innerFrames = innerFrames;
+	}
+
+	public AggregatedFrame(AbstractProtocolDataUnit[] _innerFrames) {
+		super(0,0);		
+		innerFrames = _innerFrames;
+	}
+
+	@Override
+	public AbstractProtocolDataUnit processPdu(LlcpConnectionManager connectionManager) {
+		AbstractProtocolDataUnit[] responseFrames = new AbstractProtocolDataUnit[innerFrames.length];
+		for(int i = 0; i < innerFrames.length;i++)
+		{
+			responseFrames[i] = innerFrames[i].processPdu(connectionManager);			
+		}
+		
+		return new AggregatedFrame(responseFrames);
+	}
+	
+}


### PR DESCRIPTION
Is a simple and fast solution to be compatible with AggregatedFrame
PDU's.

The response to any AggregatedFrame PDU will be another AggregatedFrame
PDU with each of the responses to the initial inner PDU's in the same
order.

The solution can be much more depurated... but it works, according to
the NFC Forum LLCP specs.

Tested using Blackberry 7.1 OS.
