### PR TITLE
Fix for infinite error loop on device disconnect.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 **/target
 **/bin
 target
+# IntelliJ Idea Project files.
+.idea/
+*.iml

--- a/nfctools-core/src/main/java/org/nfctools/spi/acs/InitiatorTerminalTagScanner.java
+++ b/nfctools-core/src/main/java/org/nfctools/spi/acs/InitiatorTerminalTagScanner.java
@@ -40,7 +40,6 @@ public class InitiatorTerminalTagScanner extends AbstractTerminalTagScanner impl
 			notifyStatus(TerminalStatus.WAITING);
 			try {
 				if (cardTerminal.waitForCardPresent(500)) {
-					failureCount = 0;
 					Card card = null;
 					try {
 						card = cardTerminal.connect("*");
@@ -54,6 +53,7 @@ public class InitiatorTerminalTagScanner extends AbstractTerminalTagScanner impl
 						waitForCardAbsent();
 					}
 				}
+				failureCount = 0;
 			}
 			catch (CardException e) {
 				failureCount++;


### PR DESCRIPTION
Added a counter to the InitiatorTerminalTagScanner class which will break the infinite loop if 5 CardExceptions occur in a row.
