### PR TITLE
Read fix, Mifare Classic ACR 122 key loading optimizations

### DIFF
--- a/nfctools-core/src/main/java/org/nfctools/mf/classic/KeyValue.java
+++ b/nfctools-core/src/main/java/org/nfctools/mf/classic/KeyValue.java
@@ -15,6 +15,8 @@
  */
 package org.nfctools.mf.classic;
 
+import java.util.Arrays;
+
 
 public class KeyValue {
 
@@ -34,4 +36,30 @@ public class KeyValue {
 		return keyValue;
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((key == null) ? 0 : key.hashCode());
+		result = prime * result + Arrays.hashCode(keyValue);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		KeyValue other = (KeyValue) obj;
+		if (key != other.key)
+			return false;
+		if (!Arrays.equals(keyValue, other.keyValue))
+			return false;
+		return true;
+	}
+
+	
 }

--- a/nfctools-core/src/main/java/org/nfctools/tags/TagInputStream.java
+++ b/nfctools-core/src/main/java/org/nfctools/tags/TagInputStream.java
@@ -71,6 +71,6 @@ public class TagInputStream extends InputStream {
 		}
 
 		byte returnByte = currentBlock[currentByte++];
-		return returnByte;
+		return returnByte & 0xFF;
 	}
 }


### PR DESCRIPTION
The Mifare Classic parts should be tested on the ACR 128 - it seems the key loading into volatile should be configurable on the number of slots + 'key structure' vs 'key number' offset. The current logic should work for ACR 122 and ACR 1222L, but both the old and the new logic seems incompatible with the spec on ACR 128.
